### PR TITLE
New version: CompactTranslatesDict v0.0.1

### DIFF
--- a/C/CompactTranslatesDict/Deps.toml
+++ b/C/CompactTranslatesDict/Deps.toml
@@ -5,3 +5,7 @@ DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FrameFun = "bbafa164-4497-5d18-87cf-33e911f89480"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+["0.0.1"]
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/C/CompactTranslatesDict/Versions.toml
+++ b/C/CompactTranslatesDict/Versions.toml
@@ -1,2 +1,5 @@
 ["0.0.0"]
 git-tree-sha1 = "04804083d260dcd84c4421b6acf7ea8a07fcc1fd"
+
+["0.0.1"]
+git-tree-sha1 = "ed573c878fd847abba04d2cf74a72c4c418a6e79"


### PR DESCRIPTION
UUID: 455b6770-8cd4-11e8-0457-dd6f5558b097
Repo: https://github.com/vincentcp/CompactTranslatesDict.jl
Tree: ed573c878fd847abba04d2cf74a72c4c418a6e79